### PR TITLE
switch from using ssh to https for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,10 +3,10 @@
 	url = https://github.com/hls-fpga-machine-learning/example-models.git
 [submodule "hls4ml/templates/catapult/ac_types"]
 	path = hls4ml/templates/catapult/ac_types
-	url = git@github.com:hlslibs/ac_types.git
+	url = https://github.com/hlslibs/ac_types.git
 [submodule "hls4ml/templates/catapult/ac_simutils"]
 	path = hls4ml/templates/catapult/ac_simutils
-	url = git@github.com:hlslibs/ac_simutils.git
+	url = https://github.com/hlslibs/ac_simutils.git
 [submodule "hls4ml/templates/catapult/ac_math"]
 	path = hls4ml/templates/catapult/ac_math
-	url = git@github.com:hlslibs/ac_math.git
+	url = https://github.com/hlslibs/ac_math.git


### PR DESCRIPTION
# Description

I think using https instead of ssh allows the test machines to more easily check out the submodules. Otherwise, it fails because there is no ssh key associated with them in github. Look at https://github.com/fastmachinelearning/hls4ml/pull/982 vs https://github.com/fastmachinelearning/hls4ml/pull/956

## Type of change

- [x] Other (Specify)
Submodule checkout method

## Tests

This should enable pytests to work in our system. Compare https://github.com/fastmachinelearning/hls4ml/pull/982 vs https://github.com/fastmachinelearning/hls4ml/pull/956

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have installed and run `pre-commit` on the files I edited or added.
- [x] I have added tests that prove my fix is effective or that my feature works.
