### PR TITLE
Add some preliminary support to specify paths to ASIC libs

### DIFF
--- a/hls4ml/backends/catapult/catapult_backend.py
+++ b/hls4ml/backends/catapult/catapult_backend.py
@@ -253,6 +253,7 @@ class CatapultBackend(FPGABackend):
         tech='fpga',
         part='xcvu13p-flga2577-2-e',
         asiclibs='nangate-45nm_beh',
+        asiclibspath=None,
         asicfifo='hls4ml_lib.mgc_pipe_mem',
         asicram='ccs_sample_mem.ccs_ram_sync_1R1W',
         fifo=None,
@@ -287,6 +288,7 @@ class CatapultBackend(FPGABackend):
             tech (str, optional): The target technology type. One of 'asic' or 'fpga'.
             part (str, optional): The FPGA part to be used. Defaults to 'xcvu13p-flga2577-2-e'.
             asiclibs (str, optional): The list of ASIC Catapult libraries to load. Defaults to 'nangate-45nm_beh'.
+            asiclibspath (str, optional): The list of paths for ASIC Catapult libraries to load. Defaults to None.
             asicfifo (str, optional): The name of the ASIC FIFO library module to use. Defaults to 'hls4ml_lib.mgc_pipe_mem'.
             asicram (str, optional): The name of the ASIC RAM library module to use.
                 Defaults to 'ccs_sample_mem.ccs_ram_sync_1R1W'.
@@ -335,6 +337,7 @@ class CatapultBackend(FPGABackend):
             config['Part'] = part if part is not None else 'xcvu13p-flga2577-2-e'
         else:
             config['ASICLibs'] = asiclibs if asiclibs is not None else 'nangate-45nm_beh'
+            config['ASICLibsPath'] = asiclibspath
         config['ASICFIFO'] = asicfifo
         config['ASICRAM'] = asicram
         config['ClockPeriod'] = clock_period if clock_period is not None else 5

--- a/hls4ml/templates/catapult/build_prj.tcl
+++ b/hls4ml/templates/catapult/build_prj.tcl
@@ -76,10 +76,15 @@ proc setup_xilinx_part { part } {
 }
 
 
-proc setup_asic_libs { args } {
+proc setup_asic_libs { libargs pathargs } {
   global env
   set do_saed 0
-  foreach lib $args {
+
+  foreach path $pathargs {
+      solution options set ComponentLibs/SearchPath $path -append
+  }
+
+  foreach lib $libargs {
     solution library add $lib -- -rtlsyntool DesignCompiler
     if { [lsearch -exact {saed32hvt_tt0p78v125c_beh saed32lvt_tt0p78v125c_beh saed32rvt_tt0p78v125c_beh} $lib] != -1 } {
       set do_saed 1

--- a/hls4ml/writer/catapult_writer.py
+++ b/hls4ml/writer/catapult_writer.py
@@ -1281,10 +1281,10 @@ class CatapultWriter(Writer):
                         if model.config.get_config_value('Part') is not None:
                             line = indent + 'setup_xilinx_part {{{}}}\n'.format(model.config.get_config_value('Part'))
                         elif model.config.get_config_value('ASICLibs') is not None:
-                            line = indent + 'setup_asic_libs {{{}}}\n'.format(model.config.get_config_value('ASICLibs'))
+                            line = indent + 'setup_asic_libs {{{}}} {{{}}}\n'.format(model.config.get_config_value('ASICLibs'), model.config.get_config_value('ASICLibsPath'))
                     else:
                         if model.config.get_config_value('Technology') == 'asic':
-                            line = indent + 'setup_asic_libs {{{}}}\n'.format(model.config.get_config_value('ASICLibs'))
+                            line = indent + 'setup_asic_libs {{{}}} {{{}}}\n'.format(model.config.get_config_value('ASICLibs'), model.config.get_config_value('ASICLibsPath'))
                         else:
                             line = indent + 'setup_xilinx_part {{{}}}\n'.format(model.config.get_config_value('Part'))
 
@@ -1383,10 +1383,10 @@ class CatapultWriter(Writer):
                             if model.config.get_config_value('Part') is not None:
                                 line = indent + 'setup_xilinx_part {{{}}}\n'.format(model.config.get_config_value('Part'))
                             elif model.config.get_config_value('ASICLibs') is not None:
-                                line = indent + 'setup_asic_libs {{{}}}\n'.format(model.config.get_config_value('ASICLibs'))
+                                line = indent + 'setup_asic_libs {{{}}} {{{}}}\n'.format(model.config.get_config_value('ASICLibs'), model.config.get_config_value('ASICLibsPath'))
                         else:
                             if model.config.get_config_value('Technology') == 'asic':
-                                line = indent + 'setup_asic_libs {{{}}}\n'.format(model.config.get_config_value('ASICLibs'))
+                                line = indent + 'setup_asic_libs {{{}}} {{{}}}\n'.format(model.config.get_config_value('ASICLibs'), model.config.get_config_value('ASICLibsPath'))
                             else:
                                 line = indent + 'setup_xilinx_part {{{}}}\n'.format(model.config.get_config_value('Part'))
                     elif '#hls-fpga-machine-learning insert invoke_args' in line:


### PR DESCRIPTION
# Description

:memo: There is currently no support for explicitly specifying a path to ASIC libraries.

- It would be useful to have a simple mechanism to specify one or more library paths so that Catapult can locate the target libraries.
- If such a solution already exists, please let me know.

## How to use it

```
config_ccs = hls4ml.utils.config.create_config(
    project_name = "my_" + model.name,
    output_dir = "my_" + model.name + "-Catapult-test",
    project_dir = "Catapult",
    backend = "Catapult",
    tech = "asic",
    asiclibs = "tcbn28hpcplusbwp30p140ssg0p81v125c_ccs_dc",
    asiclibspath = "/home/giuseppe/research/projects/smartpixels/tsmc28nm_lib",  # <=== This is the new addition
    asicfifo = "hls4ml_lib.mgc_pipe_mem",
    clock_period = 10,
    io_type = "io_stream",
    csim=0,
    SCVerify=0,
    Synth=1)
```